### PR TITLE
Add `ecmaVersion` to all Acorn `parse` calls.

### DIFF
--- a/.changeset/pretty-eels-rush.md
+++ b/.changeset/pretty-eels-rush.md
@@ -1,0 +1,5 @@
+---
+"trace-deps": patch
+---
+
+Add `ecmaVersion` to all Acorn `parse` calls (fixes #2).

--- a/packages/trace-deps/lib/trace.js
+++ b/packages/trace-deps/lib/trace.js
@@ -530,20 +530,23 @@ const traceFile = async ({
   //
   // Rather than trying to infer if a given source file is ESM vs. CJS, we just
   // try both...
+  const baseOpts = {
+    locations: true,
+    ecmaVersion: "latest", // fully modern, hipster ECMAScript
+    onComment
+  };
   let ast;
   try {
     // First try as a module.
     ast = parse(src, {
       sourceType: "module",
       allowAwaitOutsideFunction: true, // for top-level await
-      locations: true,
-      ecmaVersion: "latest", // fully modern, hipster ECMAScript
-      onComment
+      ...baseOpts
     });
   } catch (modErr) {
     // Then as script.
     try {
-      ast = parse(src, { sourceType: "script", locations: true, onComment });
+      ast = parse(src, { sourceType: "script", ...baseOpts });
     } catch (scriptErr) {
       // Use original module error, with some helper errors.
       throw new Error(`Encountered parse error in ${srcPath}: ${modErr}`);


### PR DESCRIPTION
Fixes #2 