### PR TITLE
fix: adding NPM provenance badge

### DIFF
--- a/.changeset/rich-cars-bathe.md
+++ b/.changeset/rich-cars-bathe.md
@@ -1,0 +1,7 @@
+---
+"inspectdep": patch
+"trace-deps": patch
+"trace-pkg": patch
+---
+
+Adding NPM Provenance Badge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,14 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      repository-projects: write
+      deployments: write
+      packages: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v2

--- a/packages/inspectdep/package.json
+++ b/packages/inspectdep/package.json
@@ -14,6 +14,9 @@
     "npm",
     "yarn"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "lint": "pnpm exec eslint .",
     "test": "pnpm exec mocha -r ./test/setup.js \"**/*.spec.js\"",

--- a/packages/trace-deps/package.json
+++ b/packages/trace-deps/package.json
@@ -21,6 +21,9 @@
     "require.resolve",
     "import"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "lint": "pnpm exec eslint .",
     "test": "pnpm exec mocha -r ./test/setup.js \"**/*.spec.js\"",

--- a/packages/trace-pkg/package.json
+++ b/packages/trace-pkg/package.json
@@ -24,6 +24,9 @@
     "lambda",
     "packaging"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "build:toc": "echo TODO doctoc --github --notitle --maxlevel 4 README.md",
     "build": "echo TODO yarn build:toc",


### PR DESCRIPTION
Adding [NPM package provenance](https://github.blog/2023-04-19-introducing-npm-package-provenance/) for inspectdep, trace-deps, trace-pkg releases